### PR TITLE
CSS: Enable output pane scrolling

### DIFF
--- a/assets/src/css/app.scss
+++ b/assets/src/css/app.scss
@@ -31,6 +31,7 @@ html, body, #root, #root > div.app {
   flex: 1;
   display: flex;
   flex-direction: column;
+  overflow-y: scroll;
 
   .error {
     padding: 12px;

--- a/assets/src/css/app.scss
+++ b/assets/src/css/app.scss
@@ -31,7 +31,7 @@ html, body, #root, #root > div.app {
   flex: 1;
   display: flex;
   flex-direction: column;
-  overflow-y: scroll;
+  overflow-y: auto;
 
   .error {
     padding: 12px;


### PR DESCRIPTION
Tested with current Safari and Firefox.